### PR TITLE
Fixed normal string regex to perform non-greedy search

### DIFF
--- a/yara/syntaxes/yara.tmLanguage
+++ b/yara/syntaxes/yara.tmLanguage
@@ -228,7 +228,7 @@
 			<key>name</key>
 			<string>string.quoted.double.yara</string>
 			<key>match</key>
-			<string>\".*\"</string>
+			<string>\".*?\"</string>
 		</dict>
 		<!-- regexp -->
 		<dict>

--- a/yara/syntaxes/yara.tmLanguage
+++ b/yara/syntaxes/yara.tmLanguage
@@ -228,7 +228,7 @@
 			<key>name</key>
 			<string>string.quoted.double.yara</string>
 			<key>match</key>
-			<string>\".*?\"</string>
+			<string>\"(\\.|[^\\\"])*?\"</string>
 		</dict>
 		<!-- regexp -->
 		<dict>


### PR DESCRIPTION
Fix to resolve #13.

Screenshot from VS Code after the fix:
<img width="396" alt="string_fix" src="https://user-images.githubusercontent.com/9136050/35379016-937099fe-0169-11e8-8e99-a9e547168d2a.png">
