### PR TITLE
Improve hex string begin matching

### DIFF
--- a/yara/syntaxes/yara.tmLanguage
+++ b/yara/syntaxes/yara.tmLanguage
@@ -242,7 +242,7 @@
 			<key>contentName</key>
 			<string>string.hex.yara</string>
 			<key>begin</key>
-			<string>= {</string>
+			<string>=\s*?{</string>
 			<key>end</key>
 			<string>}</string>
 		</dict>


### PR DESCRIPTION
start on `= {` with any amount of whitespace

now matches `={`