### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-![Source - https://raw.githubusercontent.com/blacktop/docker-yara/master/logo.png](./images/logo.png)
+![Source - https://raw.githubusercontent.com/blacktop/docker-yara/master/logo.png](images/logo.png)
 
 # YARA for Visual Studio Code
 Language support for the YARA pattern matching language
 
 ## Screenshot
-![Image as of 04 Sept 2016](./images/04092016.PNG)
+![Image as of 04 Sept 2016](images/04092016.PNG)
 
 ## Features
 
 ### Definition Provider and Peeking
 Allows peeking and Ctrl+clicking to jump to a rule definition. This applies to both rule names and variables
 
-![Go To Definition](./images/peek_rules.PNG)
+![Go To Definition](images/peek_rules.PNG)
 
 ### Reference Provider
 Shows the locations of a given symbol (rule name, variable, constant, etc.)
 
-![Find All References](./images/references.PNG)
+![Find All References](images/references.PNG)
 
 ### Code Completion
 Provides completion suggestions for standard YARA modules, including `pe`, `elf`, `math`, and all the others available in the official documentation: http://yara.readthedocs.io/en/v3.7.0/modules.html
 
-![Code Completion](./images/module_completion.PNG)
+![Code Completion](images/module_completion.PNG)
 
 ### Snippets
 Includes:


### PR DESCRIPTION
Tweak relative image paths. For some reason the images are busted when viewing the README from the VSCode extension explorer.  Not sure if this fixes it or not, but at least shouldn't break anything.

![image](https://user-images.githubusercontent.com/1944268/100458789-f5f41900-3089-11eb-8f02-103e764e0bc8.png)
