### PR TITLE
added debug setting and logging to output channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
         "configuration": {
             "title": "YARA",
             "properties": {
+                "yara.debug": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Toggle debug logging to the YARA output channel"
+                },
                 "yara.requireImports": {
                     "type": "boolean",
                     "default": false,

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -20,7 +20,6 @@ suite("YARA: Provider", function () {
         // line numbers start at 0, so we have to subtract one for the lookup
         const pos: vscode.Position = new vscode.Position(42, 14);
         vscode.commands.executeCommand("vscode.executeDefinitionProvider", uri, pos).then((definitions: vscode.Location[]) => {
-                // console.log(`rule definitions: ${JSON.stringify(definitions)}`);
                 assert.equal(definitions.length, 1);
                 definitions.forEach((definition: vscode.Location) => {
                     assert.equal(definition.uri.fsPath, filepath);
@@ -38,7 +37,6 @@ suite("YARA: Provider", function () {
         // line numbers start at 0, so we have to subtract one for the lookup
         const pos: vscode.Position = new vscode.Position(24, 14);
         vscode.commands.executeCommand("vscode.executeDefinitionProvider", uri, pos).then((definitions: vscode.Location[]) => {
-            // console.log(`variable definitions: ${JSON.stringify(definitions)}`);
             assert.equal(definitions.length, 1);
             definitions.forEach((definition: vscode.Location) => {
                 assert.equal(definition.uri.fsPath, filepath);
@@ -56,7 +54,6 @@ suite("YARA: Provider", function () {
         const pos: vscode.Position = new vscode.Position(21, 11);
         const acceptableLines: Set<number> = new Set([21, 28, 29]);
         vscode.commands.executeCommand("vscode.executeReferenceProvider", uri, pos).then((references: vscode.Location[]) => {
-            // console.log(`symbol references: ${JSON.stringify(references)}`);
             assert.equal(references.length, 3);
             references.forEach((reference: vscode.Location) => {
                 assert.equal(reference.uri.fsPath, filepath);
@@ -75,7 +72,6 @@ suite("YARA: Provider", function () {
         const pos: vscode.Position = new vscode.Position(30, 11);
         const acceptableLines: Set<number> = new Set([19, 20, 24]);
         vscode.commands.executeCommand("vscode.executeReferenceProvider", uri, pos).then((references: vscode.Location[]) => {
-            // console.log(`wildcard references: ${JSON.stringify(references)}`);
             assert.equal(references.length, 3);
             references.forEach((reference: vscode.Location) => {
                 assert.equal(reference.uri.fsPath, filepath);
@@ -102,7 +98,6 @@ suite("YARA: Provider", function () {
         const pos: vscode.Position = new vscode.Position(19, 11);
         const acceptableLines: Set<number> = new Set([19, 24, 40, 42]);
         vscode.commands.executeCommand("vscode.executeReferenceProvider", uri, pos).then((references: vscode.Location[]) => {
-            // console.log(`issue 17: ${JSON.stringify(references)}`);
             assert.equal(references.length, 4);
             references.forEach((reference: vscode.Location) => {
                 assert.equal(reference.uri.fsPath, filepath);
@@ -130,7 +125,6 @@ suite("YARA: Provider", function () {
         // my_private_rule: Line 10, Col 14
         const pos: vscode.Position = new vscode.Position(9, 14);
         vscode.commands.executeCommand("vscode.executeDefinitionProvider", uri, pos).then((references: vscode.Location[]) => {
-            // console.log(`issue 32: ${JSON.stringify(references)}`);
             assert.equal(references.length, 1);
             references.forEach((reference: vscode.Location) => {
                 assert.equal(reference.uri.fsPath, filepath);

--- a/yara/src/configuration.ts
+++ b/yara/src/configuration.ts
@@ -1,0 +1,18 @@
+"use strict";
+
+import * as vscode from 'vscode';
+import { log } from './helpers';
+
+export const configSection = 'yara';
+export let debug = false;
+
+export function setDebugLogState(): void {
+    if (vscode.workspace.getConfiguration(configSection).get('debug')) {
+        debug = true;
+        log('Debug logging enabled');
+    }
+    else {
+        debug = false;
+        log('Debug logging disabled');
+    }
+}

--- a/yara/src/definitionProvider.ts
+++ b/yara/src/definitionProvider.ts
@@ -1,30 +1,35 @@
 "use strict";
 
 import * as vscode from "vscode";
-import {GetRuleRange, varFirstChar, IsRuleStart} from "./helpers";
+import { debug } from "./configuration";
+import {log, GetRuleRange, varFirstChar, IsRuleStart} from "./helpers";
 
 
 export class YaraDefinitionProvider implements vscode.DefinitionProvider {
-    public provideDefinition(doc: vscode.TextDocument, pos: vscode.Position): Thenable<vscode.Location> {
+    public provideDefinition(doc: vscode.TextDocument, pos: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Location> {
         return new Promise((resolve, reject) => {
+            token.onCancellationRequested(() => {
+                if (debug) { log('YaraDefinitionProvider: Task cancelled!'); }
+                resolve(undefined);
+            });
             try {
                 let definition: vscode.Location | null = null;
                 const fileUri: vscode.Uri = vscode.Uri.file(doc.fileName);
                 const range: vscode.Range = doc.getWordRangeAtPosition(pos);
                 const symbol: string = doc.getText(range);
-                // console.log(`Providing definition for symbol '${symbol}'`);
+                if (debug) { log(`YaraDefinitionProvider: Providing definition for symbol '${symbol}'`); }
                 const possibleVarStart: vscode.Position = new vscode.Position(range.start.line, range.start.character - 1);
                 const possibleVarRange: vscode.Range = new vscode.Range(possibleVarStart, range.end);
                 const possibleVar: string = doc.getText(possibleVarRange);
                 const lines: string[] = doc.getText().split("\n");
                 if (varFirstChar.has(possibleVar.charAt(0))) {
-                    // console.log(`Variable detected: ${possibleVar}`);
+                    if (debug) { log(`YaraDefinitionProvider: Variable detected for '${possibleVar}'`); }
                     const currentRuleRange: vscode.Range = GetRuleRange(lines, pos);
-                    // console.log(`Curr rule range: ${currentRuleRange.start.line+1} -> ${currentRuleRange.end.line+1}`);
+                    if (debug) { log(`YaraDefinitionProvider: Rule range of ${currentRuleRange.start.line+1} -> ${currentRuleRange.end.line+1}`); }
                     for (let lineNo = currentRuleRange.start.line; lineNo < currentRuleRange.end.line; lineNo++) {
                         const character: number = lines[lineNo].indexOf(`$${symbol} =`);
                         if (character != -1) {
-                            // console.log(`Found definition of '${possibleVar}' on line ${lineNo + 1} at character ${character + 1}`);
+                            if (debug) { log(`YaraDefinitionProvider: Found definition of '${possibleVar}' on line ${lineNo + 1} at character ${character + 1}`); }
                             // gotta add one because VSCode won't recognize the '$' as part of the symbol
                             const defPosition: vscode.Position = new vscode.Position(lineNo, character + 1);
                             definition = new vscode.Location(fileUri, defPosition);
@@ -36,7 +41,7 @@ export class YaraDefinitionProvider implements vscode.DefinitionProvider {
                     for (let lineNo = 0; lineNo < pos.line; lineNo++) {
                         const character: number = lines[lineNo].indexOf(symbol);
                         if (character != -1 && IsRuleStart(lines[lineNo])) {
-                            // console.log(`Found ${symbol} on line ${lineNo} at character ${character}`);
+                            if (debug) { log(`YaraDefinitionProvider: Found ${symbol} on line ${lineNo} at character ${character}`); }
                             const defPosition: vscode.Position = new vscode.Position(lineNo, character);
                             definition = new vscode.Location(fileUri, defPosition);
                             break;
@@ -45,6 +50,7 @@ export class YaraDefinitionProvider implements vscode.DefinitionProvider {
                 }
                 resolve(definition);
             } catch (error) {
+                log(`YaraDefinitionProvider error: ${error}`)
                 reject(error);
             }
         });

--- a/yara/src/extension.ts
+++ b/yara/src/extension.ts
@@ -1,27 +1,46 @@
 "use strict";
 
 import * as vscode from "vscode";
-import {YaraCompletionItemProvider} from "./completionProvider";
-import {YaraDefinitionProvider} from "./definitionProvider";
-import {YaraReferenceProvider} from "./referenceProvider";
-import {YaraSnippetCompletionItemProvider} from "./snippetProvider";
+import { configSection, debug, setDebugLogState } from "./configuration";
+import { log } from "./helpers";
+import * as helpers from "./helpers";
+import { YaraCompletionItemProvider } from "./completionProvider";
+import { YaraDefinitionProvider } from "./definitionProvider";
+import { YaraReferenceProvider } from "./referenceProvider";
+import { YaraSnippetCompletionItemProvider } from "./snippetProvider";
 
 
 export function activate(context: vscode.ExtensionContext): void {
-    // console.log("Activating Yara extension");
+    // clear output channel and set up appropriate level of logging
+    helpers.output.clear();
+    log("Activating YARA extension");
+    setDebugLogState();
+    // register all the different providers for the extension
     const YARA: vscode.DocumentSelector = { language: "yara", scheme: "file" };
     const definitionDisposable: vscode.Disposable = vscode.languages.registerDefinitionProvider(YARA, new YaraDefinitionProvider());
-    const referenceDisposable: vscode.Disposable = vscode.languages.registerReferenceProvider(YARA, new YaraReferenceProvider());
-    const completionDisposable: vscode.Disposable = vscode.languages.registerCompletionItemProvider(YARA, new YaraCompletionItemProvider(), '.');
-    const snippetsDisposable: vscode.Disposable = vscode.languages.registerCompletionItemProvider(YARA, new YaraSnippetCompletionItemProvider());
+    if (debug) { log("Registered definition provider"); }
     context.subscriptions.push(definitionDisposable);
+    const referenceDisposable: vscode.Disposable = vscode.languages.registerReferenceProvider(YARA, new YaraReferenceProvider());
+    if (debug) { log("Registered reference provider"); }
     context.subscriptions.push(referenceDisposable);
+    const completionDisposable: vscode.Disposable = vscode.languages.registerCompletionItemProvider(YARA, new YaraCompletionItemProvider(), '.');
+    if (debug) { log("Registered module completion provider"); }
     context.subscriptions.push(completionDisposable);
+    const snippetsDisposable: vscode.Disposable = vscode.languages.registerCompletionItemProvider(YARA, new YaraSnippetCompletionItemProvider());
+    if (debug) { log("Registered snippet provider"); }
     context.subscriptions.push(snippetsDisposable);
+    // watch configuration for changes to update log level
+    const configWatcher: vscode.Disposable = vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+        if (e.affectsConfiguration(configSection)) {
+            setDebugLogState();
+        }
+    });
+    context.subscriptions.push(configWatcher);
+    if (debug) { log('Registered configuration watcher'); }
 }
 
 export function deactivate(context: vscode.ExtensionContext): void {
-    // console.log("Deactivating Yara extension");
+    log("Deactivating YARA extension");
     context.subscriptions.forEach(disposable => {
         disposable.dispose();
     });

--- a/yara/src/helpers.ts
+++ b/yara/src/helpers.ts
@@ -3,8 +3,16 @@
 import * as vscode from "vscode";
 
 
+export const output: vscode.OutputChannel = vscode.window.createOutputChannel("YARA");
 // variables have a few possible first characters - use these to identify vars vs. rules
 export const varFirstChar: Set<string> = new Set(["$", "#", "@", "!"]);
+
+/*
+    Send a given message to the output channel with a timestamp
+*/
+export function log(message: string): void {
+    output.appendLine(`[${new Date().toISOString()}] ${message}`);
+}
 
 /*
     Get the start and end boundaries for the current YARA rule based on a symbol's position


### PR DESCRIPTION
Closes #40 

* Added new configuration setting `yara.debug` and a configuration watcher in case it gets changed
* Added output channel "YARA", which provides logs to the user along with a new helper - `log()` - which prepends timestamps to each log line
* All providers now use the output channel instead of `console.log()`, which has been removed everywhere