### PR TITLE
Added invalid strings pattern

### DIFF
--- a/test/rules/hex_strings.yar
+++ b/test/rules/hex_strings.yar
@@ -55,7 +55,6 @@ rule AlternativesExample2
         $webshell = { 24 5f (47 45|50 4f 53) 54 5b (27|22) 63 6d 64 (27|22) 5d }
         $missing_closed_parens = { F4 23 ( 62 B4 | 56 | 45 ?? 67  45 }
         $missing_open_parens = { F4 23 62 B4 | 56 | 45 ?? 67 ) 45 }
-        $h = {ee ff gg hh ><}
     condition:
         $hex_string
 }

--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -1,0 +1,19 @@
+rule InvalidHexString
+{
+    meta:
+        description = "Example rule for vscode-yara issue #26"
+    strings:
+        $h = {ee ff gg hh ><}
+    condition:
+        any of them
+}
+rule InvalidString
+{
+    meta:
+        description = "Example rule for vscode-yara issue #28"
+    strings:
+        $invalid = "C:\Users"
+        $valid = "C:\\Users"
+    condition:
+        any of them
+}

--- a/test/rules/peek_rules.yara
+++ b/test/rules/peek_rules.yara
@@ -52,7 +52,7 @@ rule Yara4Example
         $b64wname = "string" base64wide
     condition:
         any of them
-        and pe.pdb_path == "C:\fake_pdb_path"
+        and pe.pdb_path == "C:\\fake_pdb_path"
         and pe.dll_name == "library.dll"
         and pe.export_timestamp == 000000000
         and pe.exports_index(40)

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -144,7 +144,14 @@
     },
     {
       "name": "string.quoted.double.yara",
-      "match": "\\\"(\\\\.|[^\\\\\\\"])*?\\\""
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "invalid.illegal.quoted.double.yara",
+          "match": "[^\\\\]\\\\[^\\\\]"
+        }
+      ]
     },
     {
       "name": "string.regexp.yara",
@@ -158,10 +165,6 @@
         {
           "name": "string.other.hex.yara",
           "match": "[a-fA-F0-9?]"
-        },
-        {
-          "name": "entity.special.hex.yara",
-          "match": "[(|)[-]]"
         },
         {
           "name": "invalid.illegal.hex.yara",

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -148,7 +148,7 @@
       "end": "\"",
       "patterns": [
         {
-          "name": "invalid.illegal.quoted.double.yara",
+          "name": "invalid.illegal.missing.escape.yara",
           "match": "[^\\\\]\\\\[^\\\\]"
         }
       ]


### PR DESCRIPTION
PR to address https://github.com/infosec-intern/vscode-yara/issues/28

Closes #28 

* Added `invalid.illegal.quoted.double.yara` to match quoted strings with single backslashes, which YARA considers and invalid escape sequence
* Created `invalid.yar` to catch it (and fixed another test rule that I didn't realize violated this)

![Screenshot from 2021-06-27 11-35-07](https://user-images.githubusercontent.com/15183688/123554246-47f23f80-d73c-11eb-8de6-0900979b27c6.png)
