### PR TITLE
Fix quotes in comments and hex jumps

### DIFF
--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -17,6 +17,8 @@ rule InvalidString
         $valid_escape1 = "C:\"Users\"" ascii wide
         $valid_escape2 = "C:\\\"Users\"" ascii wide
         $valid_escape3 = "C:\\\" Users \"" ascii wide
+        $valid_escape4 = "C:\\Users" ascii wide       // "quoted comment"
+        $valid_escape5 = "/root/users" ascii wide    // "quoted comment"
     condition:
         any of them
 }

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -145,7 +145,7 @@
     {
       "name": "string.quoted.double.yara",
       "begin": "\"",
-      "end": "(\")(?!.*\")",
+      "end": "(\")(?![^/]*\")",
       "patterns": [
         {
           "name": "invalid.illegal.missing.escape.yara",
@@ -162,6 +162,12 @@
       "begin": "=\\s*?{",
       "end": "}",
       "patterns": [
+        {
+          "name": "constant.numeric.jump.range.yara",
+          "begin": "\\[",
+          "end": "\\]",
+          "match": "[0-9]*-[0-9]*"
+        },
         {
           "name": "string.other.hex.yara",
           "match": "[a-fA-F0-9?]"


### PR DESCRIPTION
The negative lookahead introduced in v1.6.1 incorrectly identified quotes in comments (`//.*`) as part of the string. This PR fixes that and the entity type in hex jumps from string to numeric
