### PR TITLE
Fix broken string escapes

### DIFF
--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -14,12 +14,18 @@ rule InvalidString
     strings:
         $invalid = "C:\Users" ascii wide
         $valid = "C:\\Users" ascii wide
+        $invalid_escape1 = "C:\\\Users" ascii wide
         $valid_escape1 = "C:\"Users\"" ascii wide
         $valid_escape2 = "C:\\\"Users\"" ascii wide
         $valid_escape3 = "C:\\\" Users \"" ascii wide
         $valid_escape4 = "C:\\Users" ascii wide       // "quoted comment"
         $valid_escape5 = "/root/users" ascii wide    // "quoted comment"
         $valid_escape6 = "/\"root\"/users" ascii wide    // "quoted comment"
+        $valid_escape7 = "C:\"Users" ascii wide
+        $valid_escape8 = "C:\"Users" ascii wide     // "quoted comment"
+        $valid_escape9 = "C:\\Users\\" ascii wide
+        $valid_escape10 = "C:\\Users\\" ascii wide  // "quoted comment"
+        $valid_escape11 = "C:\\\Users\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" ascii wide
     condition:
         any of them
 }

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -145,7 +145,7 @@
     {
       "name": "string.quoted.double.yara",
       "begin": "\"",
-      "end": "[^\\\\]\"",
+      "end": "(?<=[^\\\\])(\\\\((\\\\\\\\)*\\\\))?\"",
       "patterns": [
         {
           "name": "invalid.illegal.missing.escape.yara",


### PR DESCRIPTION
Added @DissectMalware's fix for improperly escaped slashes in quoted strings. This should address issue #47 