### PR TITLE
Fix Syntax Bugs and Other Improvements

### DIFF
--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -37,8 +37,10 @@ rule EscapeSequences
         $double = "abc\"def"        // \" 	double quote
         $slash = "abc\\def"         // \\ 	backslash
         $newline = "abc\ndef"       // \n 	line feed - new line
+        $return = "abc\rdef"        // \r 	carriage return - available in 4.1.0+
         $tab = "abc\tdef"           // \t 	horizontal tab
         $hex = "abc\x12def"         // \xnn 	arbitrary hexadecimal value
+        $invalid_hex = "abc\x1Qdef"        // invalid hex sequence
     condition:
         any of them
 }

--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -1,16 +1,21 @@
-rule InvalidHexString
+rule HexStrings
 {
     meta:
-        description = "Example rule for vscode-yara issue #26"
+        description = "Example rule for vscode-yara issues #26 and #49"
     strings:
-        $h = {ee ff gg hh ><}
+        $invalid = {ee ff gg hh ><}
+        $valid_jmp = { 00 11 22 33 [-] 88 99 }
+        $valid_jmp1 = { 00 11 22 33 [4] 88 99 }
+        $valid_jmp2 = { 00 11 22 33 [4-] 88 99 }
+        $valid_jmp3 = { 00 11 22 33 [4-6] 88 99 }
+        $invalid_jmp = { 00 11 22 33 [6-4] 88 99 }
     condition:
         any of them
 }
-rule InvalidString
+rule TextStrings
 {
     meta:
-        description = "Example rule for vscode-yara issue #28"
+        description = "Example rule for vscode-yara issues #28 and #49"
     strings:
         $invalid = "C:\Users" ascii wide
         $valid = "C:\\Users" ascii wide

--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -4,11 +4,16 @@ rule HexStrings
         description = "Example rule for vscode-yara issues #26 and #49"
     strings:
         $invalid = {ee ff gg hh ><}
+        $valid = { 00 11 22 33 44 55 AA FF }
         $valid_jmp = { 00 11 22 33 [-] 88 99 }
         $valid_jmp1 = { 00 11 22 33 [4] 88 99 }
         $valid_jmp2 = { 00 11 22 33 [4-] 88 99 }
         $valid_jmp3 = { 00 11 22 33 [4-6] 88 99 }
+        $valid_jmp4 = { 00 (11|22) 33 44 55 }
         $invalid_jmp = { 00 11 22 33 [6-4] 88 99 }
+        $invalid_jmp2 = { 00 11 22 33 [aa-bb] 88 99 }
+        $valid_wildcard = { 00 ?? ?? ?? ?? 88 99 }
+        $valid_wildcard2 = { 00 1? ?2 ?? ( 44 | 5? ) 88 99 }
     condition:
         any of them
 }

--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -29,3 +29,51 @@ rule InvalidString
     condition:
         any of them
 }
+rule EscapeSequences
+{
+    meta:
+        description = "Example rule for vscode-yara issue #49"
+    strings:
+        // Simple escape sequences
+        // \' 	single quote 	byte 0x27 in ASCII encoding
+        // \" 	double quote 	byte 0x22 in ASCII encoding
+        // \? 	question mark 	byte 0x3f in ASCII encoding
+        // \\ 	backslash 	byte 0x5c in ASCII encoding
+        // \a 	audible bell 	byte 0x07 in ASCII encoding
+        // \b 	backspace 	byte 0x08 in ASCII encoding
+        // \f 	form feed - new page 	byte 0x0c in ASCII encoding
+        // \n 	line feed - new line 	byte 0x0a in ASCII encoding
+        // \r 	carriage return 	byte 0x0d in ASCII encoding
+        // \t 	horizontal tab 	byte 0x09 in ASCII encoding
+        // \v 	vertical tab 	byte 0x0b in ASCII encoding
+        $single = "abc\'def"
+        $double = "abc\"def"
+        $question = "abc\?def"
+        $tab = "abc\tdef"
+        $space = "abc\sdef"
+        $slash = "abc\\def"
+        $audible = "abc\adef"
+        $backspace = "abc\bdef"
+        $formfeed = "abc\fdef"
+        $newline = "abc\ndef"
+        $carriage = "abc\rdef"
+        $verticaltab = "abc\vdef"
+        // Numeric escape sequences
+        // \nnn 	arbitrary octal value 	byte nnn
+        // \xnn 	arbitrary hexadecimal value 	byte nn
+        $octal = "abc\012def"
+        $hex = "abc\x12def"
+        // Conditional escape sequences[1]
+        // \c 	Implementation-defined 	Implementation-defined
+        $conditional = "abc\cdef"
+        // Universal character names
+        // \unnnn 	arbitrary Unicode value;
+        // may result in several code units 	code point U+nnnn
+        // \Unnnnnnnn 	arbitrary Unicode value;
+        // may result in several code units 	code point U+nnnnnnnn
+        $unicode1 = "abc\u0123def"
+        $unicode2 = "abc\u01234567def"
+        $notunicode = "abc\u0def"
+    condition:
+        any of them
+}

--- a/test/rules/invalid.yar
+++ b/test/rules/invalid.yar
@@ -15,6 +15,7 @@ rule InvalidString
         $invalid = "C:\Users" ascii wide
         $valid = "C:\\Users" ascii wide
         $invalid_escape1 = "C:\\\Users" ascii wide
+        $invalid_escape2 = "C:\\\Users\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" ascii wide
         $valid_escape1 = "C:\"Users\"" ascii wide
         $valid_escape2 = "C:\\\"Users\"" ascii wide
         $valid_escape3 = "C:\\\" Users \"" ascii wide
@@ -25,7 +26,6 @@ rule InvalidString
         $valid_escape8 = "C:\"Users" ascii wide     // "quoted comment"
         $valid_escape9 = "C:\\Users\\" ascii wide
         $valid_escape10 = "C:\\Users\\" ascii wide  // "quoted comment"
-        $valid_escape11 = "C:\\\Users\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" ascii wide
     condition:
         any of them
 }
@@ -34,46 +34,11 @@ rule EscapeSequences
     meta:
         description = "Example rule for vscode-yara issue #49"
     strings:
-        // Simple escape sequences
-        // \' 	single quote 	byte 0x27 in ASCII encoding
-        // \" 	double quote 	byte 0x22 in ASCII encoding
-        // \? 	question mark 	byte 0x3f in ASCII encoding
-        // \\ 	backslash 	byte 0x5c in ASCII encoding
-        // \a 	audible bell 	byte 0x07 in ASCII encoding
-        // \b 	backspace 	byte 0x08 in ASCII encoding
-        // \f 	form feed - new page 	byte 0x0c in ASCII encoding
-        // \n 	line feed - new line 	byte 0x0a in ASCII encoding
-        // \r 	carriage return 	byte 0x0d in ASCII encoding
-        // \t 	horizontal tab 	byte 0x09 in ASCII encoding
-        // \v 	vertical tab 	byte 0x0b in ASCII encoding
-        $single = "abc\'def"
-        $double = "abc\"def"
-        $question = "abc\?def"
-        $tab = "abc\tdef"
-        $space = "abc\sdef"
-        $slash = "abc\\def"
-        $audible = "abc\adef"
-        $backspace = "abc\bdef"
-        $formfeed = "abc\fdef"
-        $newline = "abc\ndef"
-        $carriage = "abc\rdef"
-        $verticaltab = "abc\vdef"
-        // Numeric escape sequences
-        // \nnn 	arbitrary octal value 	byte nnn
-        // \xnn 	arbitrary hexadecimal value 	byte nn
-        $octal = "abc\012def"
-        $hex = "abc\x12def"
-        // Conditional escape sequences[1]
-        // \c 	Implementation-defined 	Implementation-defined
-        $conditional = "abc\cdef"
-        // Universal character names
-        // \unnnn 	arbitrary Unicode value;
-        // may result in several code units 	code point U+nnnn
-        // \Unnnnnnnn 	arbitrary Unicode value;
-        // may result in several code units 	code point U+nnnnnnnn
-        $unicode1 = "abc\u0123def"
-        $unicode2 = "abc\u01234567def"
-        $notunicode = "abc\u0def"
+        $double = "abc\"def"        // \" 	double quote
+        $slash = "abc\\def"         // \\ 	backslash
+        $newline = "abc\ndef"       // \n 	line feed - new line
+        $tab = "abc\tdef"           // \t 	horizontal tab
+        $hex = "abc\x12def"         // \xnn 	arbitrary hexadecimal value
     condition:
         any of them
 }

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -203,7 +203,7 @@
           "match": "[a-fA-F0-9]"
         },
         {
-          "name": "constant.other.wildcard.hex.yara",
+          "name": "constant.other.placeholder.hex.yara",
           "match": "\\?"
         },
         {

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -203,7 +203,7 @@
           "match": "[a-fA-F0-9]"
         },
         {
-          "name": "variable.language.wildcard.hex.yara",
+          "name": "constant.other.wildcard.hex.yara",
           "match": "\\?"
         },
         {

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -145,10 +145,10 @@
     {
       "name": "string.quoted.double.yara",
       "begin": "\"",
-      "end": "(?<=[^\\\\])(\\\\((\\\\\\\\)*\\\\))?\"",
+      "end": "\"",
       "patterns": [
         {
-          "name": "string.quoted.double.escape.sequence.yara",
+          "name": "constant.character.escape.yara",
           "match": "\\\\[\"\\\\nrt]"
         },
         {
@@ -166,20 +166,10 @@
       "match": "/.*?[^\\\\]/(i|c|x|t|s|m|p|w|n|J|U|d|b|e|q|x)*"
     },
     {
-      "contentName": "entity.hex.yara",
+      "contentName": "entity.name.hex.yara",
       "begin": "=\\s*?{",
       "end": "}",
       "patterns": [
-        {
-          "name": "constant.numeric.jump.range.yara",
-          "begin": "\\[",
-          "end": "\\]",
-          "match": "[0-9]*-[0-9]*"
-        },
-        {
-          "name": "string.other.hex.yara",
-          "match": "[a-fA-F0-9?]"
-        },
         {
           "name": "comment.line.double-slash.hex.yara",
           "match": "//.*\\n"
@@ -190,8 +180,39 @@
           "end": "\\*/"
         },
         {
+          "name": "entity.name.jump.hex.yara",
+          "begin": "\\[",
+          "end": "\\]",
+          "patterns": [
+            {
+              "name": "constant.numeric.jump.hex.yara",
+              "match": "[0-9]"
+            },
+            {
+              "name": "entity.other.dash.jump.hex.yara",
+              "match": "\\-"
+            },
+            {
+              "name": "invalid.illegal.jump.yara",
+              "match": "."
+            }
+          ]
+        },
+        {
+          "name": "string.other.hex.yara",
+          "match": "[a-fA-F0-9]"
+        },
+        {
+          "name": "variable.language.wildcard.hex.yara",
+          "match": "\\?"
+        },
+        {
+          "name": "entity.other.special.hex.yara",
+          "match": "[\\[\\]\\(\\)\\s|]"
+        },
+        {
           "name": "invalid.illegal.hex.yara",
-          "match": "[^(|)\\[\\-\\]a-fA-F0-9?]"
+          "match": "[^\\[\\]\\s]"
         }
       ]
     },

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -148,8 +148,16 @@
       "end": "(?<=[^\\\\])(\\\\((\\\\\\\\)*\\\\))?\"",
       "patterns": [
         {
+          "name": "string.quoted.double.escape.sequence.yara",
+          "match": "\\\\[\"\\\\nrt]"
+        },
+        {
+          "name": "string.quoted.double.hex.yara",
+          "match": "\\\\x[a-fA-F0-9]{2}"
+        },
+        {
           "name": "invalid.illegal.missing.escape.yara",
-          "match": "[^\\\\]\\\\[^\\\\\"]"
+          "match": "\\\\."
         }
       ]
     },


### PR DESCRIPTION
This PR is purely changes to the TextMate syntax. Turns out reading documentation can be helpful sometimes.

* Character and hex escapes are properly classified inside text strings
* Illegal escapes were reworked as a catch-all of any character not previously identified as an escape
* ^^ This allowed us to re-simplify the double quote "end" matcher
* Hex string entities were renamed to match TextMate recommendations
* Hex jumps were completely reworked to match every number as a numeric constant
* Illegal characters are marked as such inside hex jumps
* The hex placeholder character "?" is now defined as constant instead of lumped in with strings
* Special hex characters are reserved, such as brackets, pipes, and dashes

Closes #49 