### PR TITLE
New Snippets for escaped strings

### DIFF
--- a/yara/snippets/yara.json
+++ b/yara/snippets/yara.json
@@ -57,7 +57,7 @@
     "regex": {
         "prefix": "$re",
         "body": [
-            "\\$re = /${CLIPBOARD/([\\\\\/\\\\^\\\\$\\|(){}\\[\\]*+?])|(\\n)|(\\t)|(\\r)/${1:+\\\\}${1}${2:+\\\\n}${3:+\\\\t}${4:+\\\\r}/g}/"
+            "\\$re = /${CLIPBOARD/([\\\\\/\\\\^\\\\$\\|(){}\\[\\]*+?\\\\.])|(\\n)|(\\t)|(\\r)/${1:+\\\\}${1}${2:+\\\\n}${3:+\\\\t}${4:+\\\\r}/g}/"
         ],
         "description": "Generate a regex string with the escaped content of your clipboard"
     },
@@ -71,7 +71,7 @@
     "pasteRegex": {
         "prefix": "pasteRegex",
         "body": [
-            "${CLIPBOARD/([\\\\\/\\\\^\\\\$\\|(){}\\[\\]*+?])|(\\n)|(\\t)|(\\r)/${1:+\\\\}${1}${2:+\\\\n}${3:+\\\\t}${4:+\\\\r}/g}"
+            "${CLIPBOARD/([\\\\\/\\\\^\\\\$\\|(){}\\[\\]*+?\\\\.])|(\\n)|(\\t)|(\\r)/${1:+\\\\}${1}${2:+\\\\n}${3:+\\\\t}${4:+\\\\r}/g}"
         ],
         "description": "Paste current clipboard escaped for yara regex"
     },
@@ -80,6 +80,6 @@
         "body": [
             "\\$c ={${CLIPBOARD/[\t]*(.+?)\\n/${1}\n\t\t\t  /g}}"
         ],
-        "description": "Generate a hex-string with the content of your Clipboard"
+        "description": "Generate a hex-string with the content of your clipboard"
     }
 }

--- a/yara/snippets/yara.json
+++ b/yara/snippets/yara.json
@@ -46,5 +46,40 @@
         "prefix": "header_macho",
         "body": "uint32(0) == 0xFEEDFACF ",
         "description": "Generate a condition to check for a Mach-O file header"
+    },
+    "string": {
+        "prefix": "$s",
+        "body": [
+            "\\$s = \"${CLIPBOARD/([\\\"\\\\])/\\$1/g}\" ${1|ascii,wide|} ${2:fullword}"
+        ],
+        "description": "Generate a string with the escaped content of your clipboard"
+    },
+    "regex": {
+        "prefix": "$re",
+        "body": [
+            "\\$re = /${CLIPBOARD/([\\\\\/\\\\^\\\\$\\|(){}\\[\\]*+?])|(\\n)|(\\t)|(\\r)/${1:+\\\\}${1}${2:+\\\\n}${3:+\\\\t}${4:+\\\\r}/g}/"
+        ],
+        "description": "Generate a regex string with the escaped content of your clipboard"
+    },
+    "pasteString": {
+        "prefix": "pasteString",
+        "body": [
+            "${CLIPBOARD/([\\\"\\\\])/\\$1/g}"
+            ],
+            "description": "Paste current clipboard escaped for yara strings"
+        },
+    "pasteRegex": {
+        "prefix": "pasteRegex",
+        "body": [
+            "${CLIPBOARD/([\\\\\/\\\\^\\\\$\\|(){}\\[\\]*+?])|(\\n)|(\\t)|(\\r)/${1:+\\\\}${1}${2:+\\\\n}${3:+\\\\t}${4:+\\\\r}/g}"
+        ],
+        "description": "Paste current clipboard escaped for yara regex"
+    },
+    "hex": {
+        "prefix": "$c",
+        "body": [
+            "\\$c ={${CLIPBOARD/[\t]*(.+?)\\n/${1}\n\t\t\t  /g}}"
+        ],
+        "description": "Generate a hex-string with the content of your Clipboard"
     }
 }


### PR DESCRIPTION
I have added a few snippets to quickly paste new strings which will be escaped automatically. See gifs for reference on how i use them.




String Insertion:
![insertstring](https://user-images.githubusercontent.com/11175099/141490519-91e0f465-0368-4744-a8ce-ee4ba09f7792.gif)

Hex String:
![hex](https://user-images.githubusercontent.com/11175099/141490522-0063afdf-f54e-4f40-bc22-e9faf591ec29.gif)

Regex:
![regex](https://user-images.githubusercontent.com/11175099/141492538-a75eae73-4197-4b08-8083-6de3d183ce9f.gif)


