### PR TITLE
Yara 4.20 rc1 syntax

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 14
       - name: Build package
         run: |
           npm ci
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v1
-        id: publishToOpenVSX
+        uses: HaaLeo/publish-vscode-extension@v0
         with:
           pat: ${{ secrets.OPENVSX_PUBLISHER }}
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v0
         with:
           pat: ${{ secrets.VSCODE_PUBLISHER }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,16 +29,17 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - name: Build package
         run: |
           npm ci
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v0
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPENVSX_PUBLISHER }}
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v0
+        uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VSCODE_PUBLISHER }}
           registryUrl: https://marketplace.visualstudio.com

--- a/yara/modules/console.json
+++ b/yara/modules/console.json
@@ -1,0 +1,4 @@
+{
+    "hex": "method",
+    "log": "method"
+}

--- a/yara/snippets/yara.json
+++ b/yara/snippets/yara.json
@@ -1,11 +1,11 @@
 {
     "Import": {
         "prefix": "import",
-        "body": "import \"${1|pe,elf,cuckoo,magic,hash,math,dotnet,time|}\"",
+        "body": "import \"${1|pe,elf,cuckoo,magic,hash,math,dotnet,time,console|}\"",
         "description": "Import a YARA module"
     },
     "for..of": {
-        "prefix": "for..of",
+        "prefix": "for_of",
         "body": [
             "for ${1:any} of ${2:them} : (",
              "\t${3:boolean_expression}",
@@ -14,7 +14,7 @@
         "description": "Apply the same condition to many strings"
     },
     "for..in": {
-        "prefix": "for..in",
+        "prefix": "for_in",
         "body": [
             "for ${1:any i} in ( ${2:them} ) : (",
             "\t${3:boolean_expression}",

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -57,6 +57,10 @@
       "match": "\\bcontains\\b"
     },
     {
+      "name": "keyword.other.defined.yara",
+      "match": "\\bdefined\\b"
+    },
+    {
       "name": "keyword.other.icontains.yara",
       "match": "\\bicontains\\b"
     },


### PR DESCRIPTION
From https://github.com/VirusTotal/yara/releases/tag/v4.2.0-rc1

* Added `console` module with hex/log methods
* Added `defined` keyword

Seems like every other syntax change was already supported or added in a previous PR (e.g. math module changes). I also snuck in a change to the `for*` snippets after noticing they pop up during regular module completion since they contain periods