### PR TITLE
Pre release fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.17.0",
                 "@typescript-eslint/parser": "^4.17.0",
                 "eslint": "^7.21.0",
-                "mocha": "^8.3.1",
+                "mocha": "^10.2.0",
                 "ts-loader": "^9.2.6",
                 "typescript": "^3.7.5",
                 "vscode-test": "^1.5.1",
@@ -484,12 +484,6 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@ungap/promise-all-settled": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-            "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-            "dev": true
-        },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -717,24 +711,6 @@
                 "node": ">= 6.0.0"
             }
         },
-        "node_modules/agent-base/node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/agent-base/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -769,15 +745,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/ansi-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -791,9 +758,9 @@
             }
         },
         "node_modules/anymatch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-            "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -1005,24 +972,30 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-            "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
             "dependencies": {
-                "anymatch": "~3.1.1",
+                "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "glob-parent": "~5.1.0",
+                "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.5.0"
+                "readdirp": "~3.6.0"
             },
             "engines": {
                 "node": ">= 8.10.0"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.1"
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/chrome-trace-event": {
@@ -1154,15 +1127,20 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
             "engines": {
                 "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/debug/node_modules/ms": {
@@ -1698,6 +1676,7 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "dev": true,
+            "hasInstallScript": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -1767,9 +1746,9 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -1781,6 +1760,9 @@
             },
             "engines": {
                 "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -1851,15 +1833,6 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
         },
-        "node_modules/growl": {
-            "version": "1.10.5",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.x"
-            }
-        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1904,24 +1877,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/http-proxy-agent/node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/http-proxy-agent/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
         "node_modules/https-proxy-agent": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -1934,24 +1889,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/https-proxy-agent/node_modules/debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/https-proxy-agent/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
         },
         "node_modules/human-signals": {
             "version": "2.1.0",
@@ -2070,15 +2007,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/is-glob": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -2133,6 +2061,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2175,9 +2115,9 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-            "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -2260,15 +2200,19 @@
             "dev": true
         },
         "node_modules/log-symbols": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
             "dependencies": {
-                "chalk": "^4.0.0"
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/lru-cache": {
@@ -2342,9 +2286,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -2372,43 +2316,64 @@
             }
         },
         "node_modules/mocha": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.1.tgz",
-            "integrity": "sha512-5SBMxANWqOv5bw3Hx+HVgaWlcWcFEQDUdaUAr1AUU+qwtx6cowhn7gEDT/DwQP7uYxnvShdUOVLbTYAHOEGfDQ==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+            "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
             "dev": true,
             "dependencies": {
-                "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.1",
-                "debug": "4.3.1",
+                "chokidar": "3.5.3",
+                "debug": "4.3.4",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.6",
-                "growl": "1.10.5",
+                "glob": "7.2.0",
                 "he": "1.2.0",
-                "js-yaml": "4.0.0",
-                "log-symbols": "4.0.0",
-                "minimatch": "3.0.4",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
+                "minimatch": "5.0.1",
                 "ms": "2.1.3",
-                "nanoid": "3.1.20",
-                "serialize-javascript": "5.0.1",
+                "nanoid": "3.3.3",
+                "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
-                "which": "2.0.2",
-                "wide-align": "1.1.3",
-                "workerpool": "6.1.0",
+                "workerpool": "6.2.1",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
             },
             "bin": {
                 "_mocha": "bin/_mocha",
-                "mocha": "bin/mocha"
+                "mocha": "bin/mocha.js"
             },
             "engines": {
-                "node": ">= 10.12.0"
+                "node": ">= 14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mochajs"
+            }
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/minimatch": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+            "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/ms": {
@@ -2418,9 +2383,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-            "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -2753,9 +2718,9 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
@@ -2934,9 +2899,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-            "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -3054,31 +3019,6 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dev": true,
-            "dependencies": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/strip-final-newline": {
@@ -3252,15 +3192,6 @@
                 "uglify-js": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-            "dev": true,
-            "dependencies": {
-                "randombytes": "^2.1.0"
             }
         },
         "node_modules/terser/node_modules/acorn": {
@@ -3603,15 +3534,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^1.0.2 || 2"
-            }
-        },
         "node_modules/wildcard": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
@@ -3628,9 +3550,9 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-            "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+            "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
             "dev": true
         },
         "node_modules/wrap-ansi": {
@@ -4150,12 +4072,6 @@
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
-        "@ungap/promise-all-settled": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-            "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-            "dev": true
-        },
         "@webassemblyjs/ast": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -4357,23 +4273,6 @@
             "dev": true,
             "requires": {
                 "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
             }
         },
         "ajv": {
@@ -4401,12 +4300,6 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true
         },
-        "ansi-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-            "dev": true
-        },
         "ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4417,9 +4310,9 @@
             }
         },
         "anymatch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-            "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
             "requires": {
                 "normalize-path": "^3.0.0",
@@ -4583,19 +4476,19 @@
             }
         },
         "chokidar": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-            "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
             "requires": {
-                "anymatch": "~3.1.1",
+                "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.1",
-                "glob-parent": "~5.1.0",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.5.0"
+                "readdirp": "~3.6.0"
             }
         },
         "chrome-trace-event": {
@@ -4705,9 +4598,9 @@
             }
         },
         "debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
@@ -5187,9 +5080,9 @@
             "dev": true
         },
         "glob": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -5252,12 +5145,6 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "dev": true
         },
-        "growl": {
-            "version": "1.10.5",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-            "dev": true
-        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5288,23 +5175,6 @@
                 "@tootallnate/once": "1",
                 "agent-base": "6",
                 "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
             }
         },
         "https-proxy-agent": {
@@ -5315,23 +5185,6 @@
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
             }
         },
         "human-signals": {
@@ -5418,12 +5271,6 @@
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
-        "is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true
-        },
         "is-glob": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -5458,6 +5305,12 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true
+        },
+        "is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true
         },
         "isarray": {
@@ -5496,9 +5349,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-            "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
@@ -5566,12 +5419,13 @@
             "dev": true
         },
         "log-symbols": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
             "requires": {
-                "chalk": "^4.0.0"
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
             }
         },
         "lru-cache": {
@@ -5627,9 +5481,9 @@
             "dev": true
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
@@ -5651,36 +5505,52 @@
             }
         },
         "mocha": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.1.tgz",
-            "integrity": "sha512-5SBMxANWqOv5bw3Hx+HVgaWlcWcFEQDUdaUAr1AUU+qwtx6cowhn7gEDT/DwQP7uYxnvShdUOVLbTYAHOEGfDQ==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+            "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
             "dev": true,
             "requires": {
-                "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.1",
-                "debug": "4.3.1",
+                "chokidar": "3.5.3",
+                "debug": "4.3.4",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.6",
-                "growl": "1.10.5",
+                "glob": "7.2.0",
                 "he": "1.2.0",
-                "js-yaml": "4.0.0",
-                "log-symbols": "4.0.0",
-                "minimatch": "3.0.4",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
+                "minimatch": "5.0.1",
                 "ms": "2.1.3",
-                "nanoid": "3.1.20",
-                "serialize-javascript": "5.0.1",
+                "nanoid": "3.3.3",
+                "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
-                "which": "2.0.2",
-                "wide-align": "1.1.3",
-                "workerpool": "6.1.0",
+                "workerpool": "6.2.1",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+                    "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
             }
         },
         "ms": {
@@ -5690,9 +5560,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-            "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
             "dev": true
         },
         "natural-compare": {
@@ -5938,9 +5808,9 @@
             }
         },
         "readdirp": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
             "requires": {
                 "picomatch": "^2.2.1"
@@ -6057,9 +5927,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-            "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
@@ -6155,25 +6025,6 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
-            }
-        },
-        "string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dev": true,
-            "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            }
-        },
-        "strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^3.0.0"
             }
         },
         "strip-final-newline": {
@@ -6305,17 +6156,6 @@
                 "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^5.7.2"
-            },
-            "dependencies": {
-                "serialize-javascript": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-                    "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-                    "dev": true,
-                    "requires": {
-                        "randombytes": "^2.1.0"
-                    }
-                }
             }
         },
         "text-table": {
@@ -6548,15 +6388,6 @@
                 "isexe": "^2.0.0"
             }
         },
-        "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "dev": true,
-            "requires": {
-                "string-width": "^1.0.2 || 2"
-            }
-        },
         "wildcard": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
@@ -6570,9 +6401,9 @@
             "dev": true
         },
         "workerpool": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-            "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+            "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
             "dev": true
         },
         "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         "@typescript-eslint/eslint-plugin": "^4.17.0",
         "@typescript-eslint/parser": "^4.17.0",
         "eslint": "^7.21.0",
-        "mocha": "^8.3.1",
+        "mocha": "^10.2.0",
         "ts-loader": "^9.2.6",
         "typescript": "^3.7.5",
         "vscode-test": "^1.5.1",

--- a/test/snippets.test.ts
+++ b/test/snippets.test.ts
@@ -315,7 +315,7 @@ suite('Rule Snippet', function () {
             '\t\tauthor = "$2"',
             '\t\tdate = "${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}"',
             '\tstrings:',
-            '\t\t${3:name} = ${4|"string",/regex/,{ HEX \\}|}',
+            '\t\t\\$${3:name} = ${4|"string",/regex/,{ HEX \\}|}',
             '\tcondition:',
             '\t\t${5:any of them}',
             '\\}',
@@ -365,7 +365,7 @@ suite('Strings Snippet', function () {
         assert.equal(item.label, 'strings');
         assert.equal(item.kind, vscode.CompletionItemKind.Snippet);
         assert.equal(item.detail, 'Generate a strings section (YARA)');
-        const expectedInsertText: vscode.SnippetString = new vscode.SnippetString('strings:\n\t\$${1:name} = "${2:string}"');
+        const expectedInsertText: vscode.SnippetString = new vscode.SnippetString('strings:\n\t$${1:name} = "${2:string}"');
         assert.deepEqual(item.insertText, expectedInsertText);
         const expectedDocs: vscode.MarkdownString = new vscode.MarkdownString('');
         expectedDocs.appendCodeblock('strings:\n\t$NAME = "STRING"');
@@ -382,7 +382,7 @@ suite('Strings Snippet', function () {
         assert.equal(item.label, 'strings');
         assert.equal(item.kind, vscode.CompletionItemKind.Snippet);
         assert.equal(item.detail, 'Generate a strings section (YARA)');
-        const expectedInsertText: vscode.SnippetString = new vscode.SnippetString('strings:\n\t\$${1:name} = ${2|"string",/regex/,{ HEX \\}|}');
+        const expectedInsertText: vscode.SnippetString = new vscode.SnippetString('strings:\n\t\\$${1:name} = ${2|"string",/regex/,{ HEX \\}|}');
         assert.deepEqual(item.insertText, expectedInsertText);
         const expectedDocs: vscode.MarkdownString = new vscode.MarkdownString('');
         expectedDocs.appendCodeblock('strings:\n\t$NAME = "STRING"');

--- a/yara/src/lib/hoverProvider.ts
+++ b/yara/src/lib/hoverProvider.ts
@@ -71,13 +71,13 @@ export class YaraHexStringHoverProvider implements vscode.HoverProvider {
                 const openParens: number = (fullTerm.match(/\(/g)||[]).length;
                 const closeParens: number = (fullTerm.match(/\)/g)||[]).length;
                 if (openParens > closeParens) {
-                    const errorMsg = 'YaraHexStringHoverProvider: Not a valid hex string. Expected ")"';
-                    if (debug) { log(errorMsg); }
+                    const errorMsg = 'Not a valid hex string. Expected ")"';
+                    if (debug) { log(`YaraHexStringHoverProvider: ${errorMsg}`); }
                     hover = new vscode.Hover(errorMsg, innerRange);
                 }
                 else if (openParens < closeParens) {
-                    const errorMsg = 'YaraHexStringHoverProvider: Not a valid hex string. Expected "("';
-                    if (debug) { log(errorMsg); }
+                    const errorMsg = 'Not a valid hex string. Expected "("';
+                    if (debug) { log(`YaraHexStringHoverProvider: ${errorMsg}`); }
                     hover = new vscode.Hover(errorMsg, innerRange);
                 }
                 else {

--- a/yara/src/lib/snippetProvider.ts
+++ b/yara/src/lib/snippetProvider.ts
@@ -104,9 +104,8 @@ function generateStringSnippet(snippet: vscode.SnippetString = new vscode.Snippe
     if (debug) { log('YaraSnippetCompletionItemProvider: Generating strings snippet'); }
     const tabs = '\t'.repeat(numTabs);
     snippet.appendText(`${tabs}strings:\n`);
-    snippet.appendText(`${tabs}\t`);
-    // eslint-disable-next-line no-useless-escape
-    snippet.appendPlaceholder('\$name');
+    snippet.appendText(`${tabs}\t$`);
+    snippet.appendPlaceholder('name');
     snippet.appendText(' = ');
     // TODO: Find a way to mix choices and placeholders, so user can just hit TAB to replace the value
     snippet.appendChoice(['"string"', '/regex/', '{ HEX }']);
@@ -144,8 +143,7 @@ export class YaraSnippetCompletionItemProvider implements vscode.CompletionItemP
         if (config.get('snippets.strings')) {
             const stringsItem: vscode.CompletionItem = new vscode.CompletionItem('strings', vscode.CompletionItemKind.Snippet);
             stringsItem.detail = 'Generate a strings section (YARA)';
-            // eslint-disable-next-line no-useless-escape
-            stringsItem.insertText = new vscode.SnippetString('strings:\n\t\$${1:name} = "${2:string}"');
+            stringsItem.insertText = new vscode.SnippetString('strings:\n\t$${1:name} = "${2:string}"');
             stringsItem.documentation = new vscode.MarkdownString('');
             stringsItem.documentation.appendCodeblock('strings:\n\t$NAME = "STRING"');
             items.items.push(stringsItem);

--- a/yara/src/lib/snippetProvider.ts
+++ b/yara/src/lib/snippetProvider.ts
@@ -105,6 +105,7 @@ function generateStringSnippet(snippet: vscode.SnippetString = new vscode.Snippe
     const tabs = '\t'.repeat(numTabs);
     snippet.appendText(`${tabs}strings:\n`);
     snippet.appendText(`${tabs}\t`);
+    // eslint-disable-next-line no-useless-escape
     snippet.appendPlaceholder('\$name');
     snippet.appendText(' = ');
     // TODO: Find a way to mix choices and placeholders, so user can just hit TAB to replace the value
@@ -143,6 +144,7 @@ export class YaraSnippetCompletionItemProvider implements vscode.CompletionItemP
         if (config.get('snippets.strings')) {
             const stringsItem: vscode.CompletionItem = new vscode.CompletionItem('strings', vscode.CompletionItemKind.Snippet);
             stringsItem.detail = 'Generate a strings section (YARA)';
+            // eslint-disable-next-line no-useless-escape
             stringsItem.insertText = new vscode.SnippetString('strings:\n\t\$${1:name} = "${2:string}"');
             stringsItem.documentation = new vscode.MarkdownString('');
             stringsItem.documentation.appendCodeblock('strings:\n\t$NAME = "STRING"');

--- a/yara/syntaxes/yara.tmLanguage.json
+++ b/yara/syntaxes/yara.tmLanguage.json
@@ -708,10 +708,7 @@
         },
         {
           "name": "constant.numeric.hex.yara",
-          "match": "\\b(0x)[0-9A-Fa-f]+\\b",
-          "captures": {
-            "1": {"name": "storage.modifier.number.yara"}
-          }
+          "match": "\\b0x[0-9A-Fa-f]+\\b"
         },
         {
           "name": "constant.numeric.oct.yara",


### PR DESCRIPTION
... before the v2.1.0 release

* remove dbg provider name from hover output
* keep '0x' same textmate class as rest of hex number
* move string identifier prefix '$' to outside of tabstop and fix up tests
* bump packages